### PR TITLE
Add the proto-go repository

### DIFF
--- a/go.opentelemetry.io/vanity.yaml
+++ b/go.opentelemetry.io/vanity.yaml
@@ -7,3 +7,5 @@ paths:
     repo: https://github.com/open-telemetry/opentelemetry-collector
   /contrib:
     repo: https://github.com/open-telemetry/opentelemetry-go-contrib
+  /proto:
+    repo: https://github.com/open-telemetry/opentelemetry-proto-go


### PR DESCRIPTION
This adds the go.opentelemetry.io/proto vanity url.  The expected imports will be from `go.opentelemetry.io/proto/otlp/*`

This will not be useable until the [code generated PR](https://github.com/open-telemetry/opentelemetry-proto-go/pull/1) and the follow on PR, with the generated code, are merged.