### PR TITLE
Add entry for open-telemetry/opentelemetry-go-instrumentation

### DIFF
--- a/go.opentelemetry.io/vanity.yaml
+++ b/go.opentelemetry.io/vanity.yaml
@@ -11,3 +11,5 @@ paths:
     repo: https://github.com/open-telemetry/opentelemetry-proto-go
   /build-tools:
     repo: https://github.com/open-telemetry/opentelemetry-go-build-tools
+  /auto:
+    repo: https://github.com/open-telemetry/opentelemetry-go-instrumentation


### PR DESCRIPTION
Create an alias for `go.opentelemety.io/auto`

cc @open-telemetry/go-instrumentation-approvers