### PR TITLE
Add entry for opentelemetry-collector-contrib

### DIFF
--- a/go.opentelemetry.io/vanity.yaml
+++ b/go.opentelemetry.io/vanity.yaml
@@ -5,6 +5,8 @@ paths:
     repo: https://github.com/open-telemetry/opentelemetry-go
   /collector:
     repo: https://github.com/open-telemetry/opentelemetry-collector
+  /collector-contrib:
+    repo: https://github.com/open-telemetry/opentelemetry-collector-contrib
   /contrib:
     repo: https://github.com/open-telemetry/opentelemetry-go-contrib
   /proto:


### PR DESCRIPTION
This is to allow scope name to eventually use the vanity URL to identify the source of telemetry for components in that repository. Related issue: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/21469