### PR TITLE
Use OTel fork of vanityurls and change GCP project

### DIFF
--- a/go.opentelemetry.io/deploy.sh
+++ b/go.opentelemetry.io/deploy.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-git clone https://github.com/GoogleCloudPlatform/govanityurls.git \
+git clone https://github.com/open-telemetry/govanityurls.git \
     && cp vanity.yaml govanityurls \
     && cd govanityurls \
-    && gcloud app deploy --project=opentelemetry-go
+    && gcloud app deploy --project=golang-imports


### PR DESCRIPTION
Before merging: The CircleCI service account needs access to the new GCP project