### PR TITLE
Add entry for ebpf profiler

### DIFF
--- a/go.opentelemetry.io/vanity.yaml
+++ b/go.opentelemetry.io/vanity.yaml
@@ -15,3 +15,5 @@ paths:
     repo: https://github.com/open-telemetry/opentelemetry-go-build-tools
   /auto:
     repo: https://github.com/open-telemetry/opentelemetry-go-instrumentation
+  /ebpf-profiler:
+    repo: https://github.com/open-telemetry/opentelemetry-ebpf-profiler


### PR DESCRIPTION
So we can stop relying on `github.com/...` imports, and move them to `go.opentelemetry.io/ebpf-profiler`.

cc @open-telemetry/ebpf-profiler-approvers @open-telemetry/ebpf-profiler-maintainers 