### PR TITLE
Revert "Migrate from CircleCI to GitHub Actions (#21)"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,18 +1,10 @@
-name: Build
-
-on:
-  push:
-    branches:
-      - main
-
+version: 2.1
 jobs:
-  build:
-    runs-on: ubuntu-latest
+  deploy:
+    docker:
+      - image: google/cloud-sdk@sha256:04dbcfd6e6df1d10420d1de94607f8383cc887a5ca81bcc620d037b8a3c1f95a
     steps:
-      - uses: google-github-actions/setup-gcloud@v2
-
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2 
-
+      - checkout
       - run: |
           echo $GCLOUD_SERVICE_KEY | gcloud auth activate-service-account --key-file=-
           gcloud --quiet config set project ${GOOGLE_PROJECT_ID}
@@ -20,3 +12,12 @@ jobs:
           cd go.opentelemetry.io
           chmod 755 deploy.sh
           ./deploy.sh
+
+workflows:
+  deploy:
+    jobs:
+      - deploy:
+          filters:
+            branches:
+              only:
+                - main


### PR DESCRIPTION
This reverts commit 9080f9d017206e03d44f1b461ee3d3fdc35e9e92.

See CI failure:
https://github.com/open-telemetry/opentelemetry-go-vanityurls/actions/runs/15992379577/job/45108041754

> ERROR: (gcloud.auth.activate-service-account) Missing required argument [ACCOUNT]: An account is required when using .p12 keys

It's also possible the only missing thing is a secret, and setting it would avoid having to revert.

cc @trask 