### PR TITLE
Add entry for OpenTelemetry eBPF Instrumentation

### DIFF
--- a/go.opentelemetry.io/vanity.yaml
+++ b/go.opentelemetry.io/vanity.yaml
@@ -17,3 +17,5 @@ paths:
     repo: https://github.com/open-telemetry/opentelemetry-go-instrumentation
   /ebpf-profiler:
     repo: https://github.com/open-telemetry/opentelemetry-ebpf-profiler
+  /obi:
+    repo: https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation


### PR DESCRIPTION
Name the package after the project adopted acronym `obi` (**O**penTelemetry e**B**PF **I**nstrumentation).

Resolve https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/issues/293

cc @open-telemetry/ebpf-instrumentation-approvers 