### PR TITLE
Setup hugo and netlify configuration for static site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 */govanityurls/
+
+/public/
+.hugo_build.lock

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 
 /public/
 .hugo_build.lock
+
+# Local Netlify folder
+.netlify

--- a/README.md
+++ b/README.md
@@ -1,6 +1,86 @@
 # go.opentelemetry.io
 Vanityurls config for go.opentelemetry.io subdomain
 
+## Architecture
+
+The Hugo build is organized around a lightweight template that renders each
+vanity path into a small HTML document containing the metadata used by the `go`
+toolchain.
+
+### Structure
+
+```
+/
+├── content/
+│   └── packages/PACKAGE_NAME.md
+├── themes/default
+│   └── layouts/_default/single.html
+└── config.toml
+└── netlify.toml
+```
+
+### How it works
+
+1. **Each module or submodule is represented as a page** in the `content/packages`
+	 directory.
+2. Each page contains front matter defining:
+
+	* The path to the repo this module is in.
+3. A single Hugo template (`themes/default/layouts/_default/single.html`) renders the page into
+	 the minimal HTML required for Go module resolution.
+4. The result is a fully static directory structure like:
+
+	 ```
+	 public/packages/
+	 ├── otel/index.html
+	 ```
+
+### Redirects
+
+To handle sumodules, we rely on Netlify's redirect feature.
+In `netlify.toml`, we instruct to:
+
+* Redirect `/:name` to `/packages/:name`, for each root package.
+* Redirect `/:name/*` to `/packages/:name`, for each submodule.
+
+### Meta Tags
+
+We use Go's [Remote Import
+Paths](https://pkg.go.dev/cmd/go#hdr-Remote_import_paths) to properly get Go to
+redirect from the canonical URL to its repository.
+Each vanity HTML page contains:
+
+#### go-import
+
+```
+<meta name="go-import" content="go.opentelemetry.io/otel git https://github.com/open-telemetry/opentelemetry-go">
+```
+
+This instructs the Go toolchain to fetch the module from GitHub using Git.
+
+#### go-source
+
+```
+<meta name="go-source" content="go.opentelemetry.io/otel https://github.com/open-telemetry/opentelemetry-go https://github.com/open-telemetry/opentelemetry-go/tree/main{/dir} https://github.com/open-telemetry/opentelemetry-go/blob/main{/dir}/{file}#L{line}">
+```
+
+These tags are derived from the front matter of each module's content file.
+
+### Homepage
+
+The homepage automatically lists all main modules the app handles.
+
+```
+/
+├── content/
+│   └── _index.md
+├── layouts/shortcodes
+│   └── package-list.html
+```
+
+The `package-list` shortcode generates the list of packages, and is used with
+the Hugo DSL within the `_index.md` page.
+
 ## Adding a new package
 
 Packages are configured in the `content/packages` folder. Each of them has a

--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
 # go.opentelemetry.io
 Vanityurls config for go.opentelemetry.io subdomain
+
+## Adding a new package
+
+Packages are configured in the `content/packages` folder. Each of them has a
+content file with the package name.
+
+Create a new file in `content/packages/<YOUR PACKAGE NAME>.md`. For example,
+`content/packages/my_package.md`.
+
+Add the following header to the document:
+
+```markdown
+---
+repo: URL TO THE REPOSITORY
+---
+```
+
+Where the URL to the repository is the location of the source code you need the
+package to point to.

--- a/content/_index.md
+++ b/content/_index.md
@@ -1,0 +1,1 @@
+# go.opentelemetry.io

--- a/content/_index.md
+++ b/content/_index.md
@@ -1,1 +1,3 @@
 # go.opentelemetry.io
+
+{{< packages-list >}}

--- a/content/packages/auto.md
+++ b/content/packages/auto.md
@@ -1,0 +1,3 @@
+---
+repo: https://github.com/open-telemetry/opentelemetry-go-instrumentation
+---

--- a/content/packages/build-tools.md
+++ b/content/packages/build-tools.md
@@ -1,0 +1,3 @@
+---
+repo: https://github.com/open-telemetry/opentelemetry-go-build-tools
+---

--- a/content/packages/collector-contrib.md
+++ b/content/packages/collector-contrib.md
@@ -1,0 +1,3 @@
+---
+repo: https://github.com/open-telemetry/opentelemetry-collector-contrib
+---

--- a/content/packages/collector.md
+++ b/content/packages/collector.md
@@ -1,0 +1,3 @@
+---
+repo: https://github.com/open-telemetry/opentelemetry-collector
+---

--- a/content/packages/contrib.md
+++ b/content/packages/contrib.md
@@ -1,0 +1,3 @@
+---
+repo: https://github.com/open-telemetry/opentelemetry-go-contrib
+---

--- a/content/packages/ebpf-profiler.md
+++ b/content/packages/ebpf-profiler.md
@@ -1,0 +1,3 @@
+---
+repo: https://github.com/open-telemetry/opentelemetry-ebpf-profiler
+---

--- a/content/packages/obi.md
+++ b/content/packages/obi.md
@@ -1,0 +1,3 @@
+---
+repo: https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation
+---

--- a/content/packages/otel.md
+++ b/content/packages/otel.md
@@ -1,0 +1,3 @@
+---
+repo: https://github.com/open-telemetry/opentelemetry-go
+---

--- a/content/packages/proto.md
+++ b/content/packages/proto.md
@@ -1,0 +1,3 @@
+---
+repo: https://github.com/open-telemetry/opentelemetry-proto-go
+---

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,0 +1,2 @@
+baseURL = 'https://go.opentelemetry.io/'
+theme = 'default'

--- a/layouts/shortcodes/packages-list.html
+++ b/layouts/shortcodes/packages-list.html
@@ -1,0 +1,6 @@
+{{ $packages := site.GetPage "section" "packages" }}
+<ul>
+{{ range $packages.Pages }}
+  <li><a href="/{{ .File.BaseFileName }}">go.opentelemetry.io/{{ .File.BaseFileName }}</a></li>
+{{ end }}
+</ul>

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,30 @@
+[build]
+publish = "public"
+command = "hugo --gc --minify"
+
+[build.environment]
+HUGO_VERSION = "0.150.1"
+
+#
+# Always serve files under /packages/* directly, no more rewrites
+#
+[[redirects]]
+from = "/packages/:name/*"
+to = "/packages/:name/"
+status = 200
+
+#
+# Redirect the package's root path
+#
+[[redirects]]
+from = "/:name"
+to = "/packages/:name/"
+status = 200 # ensure that the URL stays the same, see https://docs.netlify.com/routing/redirects/rewrites-proxies/
+
+#
+# Redirect every subpath within the package's root
+#
+[[redirects]]
+from = "/:name/*"
+to = "/packages/:name/"
+status = 200 # ensure that the URL stays the same, see https://docs.netlify.com/routing/redirects/rewrites-proxies/

--- a/themes/default/layouts/_default/baseof.html
+++ b/themes/default/layouts/_default/baseof.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html>
+	<head>
+		<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+		{{- if isset .Params "repo" }}
+			<meta name="go-import" content="{{ (index (split (urls.Parse .Site.BaseURL).Host ":") 0) }}/{{ .File }} git {{ .Params.repo }}">
+			<meta name="go-source" content="{{ (index (split (urls.Parse .Site.BaseURL).Host ":") 0) }}/{{ .File }} {{ .Params.repo }} {{ .Params.repo }}/tree/master{/dir} {{ .Params.repo }}/blob/master{/dir}/{file}#L{line}">
+			<meta http-equiv="refresh" content="0; url=https://pkg.go.dev/{{ (index (split (urls.Parse .Site.BaseURL).Host ":") 0) }}/{{ .File }}">
+		{{- end }}
+	</head>
+	<body>
+		{{ block "main" . }}{{ end }}
+	</body>
+</html>

--- a/themes/default/layouts/_default/index.html
+++ b/themes/default/layouts/_default/index.html
@@ -1,0 +1,3 @@
+{{ define "main" }}
+	{{ .Content }}
+{{ end }}

--- a/themes/default/layouts/_default/single.html
+++ b/themes/default/layouts/_default/single.html
@@ -1,0 +1,3 @@
+{{ define "main" }}
+	Nothing to see here; <a href="https://pkg.go.dev/{{ (index (split (urls.Parse .Site.BaseURL).Host ":") 0) }}/{{ .File }}">see the package on pkg.go.dev</a>.
+{{ end }}


### PR DESCRIPTION
This is a proposal solution for https://github.com/open-telemetry/opentelemetry-go-vanityurls/issues/83
Based on @svrnm's work in https://github.com/open-telemetry/opentelemetry.io/pull/5022, it does the following:

* Sets up [hugo](https://gohugo.io/)
* Sets up all the packages we currently have
* Sets up redirections so the packages and all their sub-urls are properly rendered.

This cannot be tested with the `netlify dev` command, as they appear to have a mismatch in behavior between that command and their production environment in how they handle redirects.

However this can be tested on https://test-go-vanity-urls.netlify.app/

This PR purposefully does not remove the current setup, so we can possibly rollback the migration if we need to.
The cleanup will happen in another PR once the migration has happened.