### PR TITLE
Add entry for OpenTelemetry Go Compile Instrumentation

### DIFF
--- a/go.opentelemetry.io/vanity.yaml
+++ b/go.opentelemetry.io/vanity.yaml
@@ -19,3 +19,5 @@ paths:
     repo: https://github.com/open-telemetry/opentelemetry-ebpf-profiler
   /obi:
     repo: https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation
+  /otelc:
+    repo: https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation


### PR DESCRIPTION
Use project's official acronym, `otelc` (**O**pen**Tel**emetry Go **C**ompile Instrumentation), as the package path.

Corresponding module path update PR: https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/pull/656

Part of https://github.com/open-telemetry/opentelemetry-go-compile-instrumentation/issues/627

cc @open-telemetry/go-compile-instrumentation-approvers 
